### PR TITLE
Fix: add hit areas to the tooltip

### DIFF
--- a/src/Components/TooltipChar.tsx
+++ b/src/Components/TooltipChar.tsx
@@ -13,13 +13,19 @@ import { noop } from "../consts";
 import type { Entry } from "../consts";
 
 const Wrapper = styled.div`
-  padding-bottom: 3px;
+  padding-top: 10px;
+  margin-top: -10px;
+  padding-bottom: 5px;
+  margin-bottom: -5px;
   overflow-wrap: break-word;
   white-space: pre-wrap;
   white-space: break-spaces;
 `;
 const Item = styled.p<{ textColor: string }>`
   margin: 2px 10px;
+  &:last-child {
+    margin-bottom: 5px;
+  }
   color: ${({ textColor }) => textColor};
   ${({ onClick }) =>
     onClick &&


### PR DESCRIPTION
Previously, when the tooltip is displayed below the text (= when the text is at the top of the window), it always disappears when trying to move the mouse pointer from the text onto it, because their is a gap between the text and the tooltip.